### PR TITLE
fix: add gatsby-plugin-google-analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,5 +14,12 @@ module.exports = {
         pathToConfigModule: 'src/styles/typography.js',
       },
     },
+
+    {
+      resolve: 'gatsby-plugin-google-analytics',
+      options: {
+        trackingId: 'UA-108251862-1',
+      },
+    },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5393,6 +5393,14 @@
         "loader-utils": "0.2.17"
       }
     },
+    "gatsby-plugin-google-analytics": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-1.0.12.tgz",
+      "integrity": "sha512-QRmYpwe9dXEMlyj3RcIUtWlE+2Ll4YQDJwEnbmXOnGoigVO8XyiQ3Vm23cXdKF2A9X0qpOz0cIW8uReJruB+3w==",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
     "gatsby-plugin-react-helmet": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-1.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "gatsby": "^1.9.77",
     "gatsby-link": "^1.6.17",
+    "gatsby-plugin-google-analytics": "^1.0.12",
     "gatsby-plugin-react-helmet": "^1.0.5",
     "gatsby-plugin-styled-components": "^1.0.5",
     "gatsby-plugin-typography": "^1.7.10",

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -4,7 +4,7 @@ import Link from 'gatsby-link';
 import Helmet from 'react-helmet';
 import { config, analytics } from '../utils';
 
-analytics.start();
+// analytics.start();
 
 const TemplateWrapper = ({ children }) => (
   <div>


### PR DESCRIPTION
add gatsby-plugin-google-analytics as an alternative to my own custom rolled solution with better
integration to Gatsby and routing suport