### PR TITLE
ci: manifest width as number

### DIFF
--- a/scripts/screenshots-compare.js
+++ b/scripts/screenshots-compare.js
@@ -28,7 +28,7 @@ const createGenericManifestData = fileName => {
     .reverse();
   const section = sectionSnippets.reverse().join('-');
 
-  return { fileName, width, section };
+  return { fileName, width: parseInt(width, 10), section };
 };
 
 const createComparisonRawData = async fileName => {


### PR DESCRIPTION
change manifest width entries from a string to a number to make sorting easier inside our Lambda SES
creation sequence